### PR TITLE
remove trailing '/' from project path (windows)

### DIFF
--- a/schemas/projects.js
+++ b/schemas/projects.js
@@ -271,8 +271,12 @@ NEWSCHEMA('Projects', function(schema) {
 
 		model.isexternal = (/(https|http):\/\//).test(model.path);
 
-		if (!model.isexternal)
-			model.path = U.path(model.path.replace(/\/\//g, '/').replace(/\\\\/g, '\\'));
+		if (!model.isexternal) {
+			model.path = U.path(
+				model.path.replace(/\/\//g, '/').replace(/\\\\/g, '\\'),
+				F.isWindows ? '\\' : '/'
+			);
+		}
 
 		for (var i = 0; i < model.users.length; i++) {
 			if (MAIN.users.findItem('id', model.users[i]))


### PR DESCRIPTION
This allows me to run code on windows (there is a problem with a trailing '/' in the folder path).

This fixes those problems for me (there may be others, I have not encountered yet - but at least autodection and editing works).
I cant tell if I broke something for unix ...

config:
backup                : D:/Projects/backup/
autodiscover       : D:/Projects/web/total4/

images of things fixed:
![missin-1st-char](https://user-images.githubusercontent.com/8170229/123405998-b7382a00-d5aa-11eb-8bad-dabed95833dc.png)
![duplication-in-list](https://user-images.githubusercontent.com/8170229/123406007-ba331a80-d5aa-11eb-8e7b-0f31fd58852b.png)

![after-auto-discover](https://user-images.githubusercontent.com/8170229/123405971-af788580-d5aa-11eb-8997-100fe23ebe7d.png)


